### PR TITLE
fix link and escape for markdown in migrate.js

### DIFF
--- a/bin/migrate.js
+++ b/bin/migrate.js
@@ -66,10 +66,10 @@ mongoose.Promise = global.Promise;
 				今回はライブコードゴルフ完全初心者同士の対決なので、初心者に不親切な言語の資料と、ヒントを用意しました。
 				適宜活用してください。
 				### 言語
-				* Emoji：https://github.com/n4o847/esolangs/wiki/Emoji
-				* PPAP：https://github.com/n4o847/esolangs/wiki/PPAP
-				* ><>：https://github.com/n4o847/esolangs/wiki/Fish
-				* Brainfuck：https://github.com/n4o847/esolangs/wiki/Brainfuck
+				* Emoji：[https://github.com/n4o847/esolangs/wiki/Emoji](https://github.com/n4o847/esolangs/wiki/Emoji)
+				* PPAP：[https://github.com/n4o847/esolangs/wiki/PPAP](https://github.com/n4o847/esolangs/wiki/PPAP)
+				* \><>：[https://github.com/n4o847/esolangs/wiki/Fish](https://github.com/n4o847/esolangs/wiki/Fish)
+				* Brainfuck：[https://github.com/n4o847/esolangs/wiki/Brainfuck](https://github.com/n4o847/esolangs/wiki/Brainfuck)
 				### ヒント
 				* ライブコードゴルフは早く出すことが正義で、そして一般にesoによるループは難しいです。愚直に26回書くことも検討してみては？
 				## 入出力例


### PR DESCRIPTION
Markdown用にURLをリンク化して><>をエスケープ